### PR TITLE
Set charset to utf8 to handle curly quotes

### DIFF
--- a/global.html
+++ b/global.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <script type="text/javascript">
       safari.application.addEventListener('message', function handleMessage(e) {
         switch (e.name) {


### PR DESCRIPTION
In Safari 6 on Mountain Lion, the curly quote characters were showing up
percent-encoded. Adding a charset to global.html fixed it for me.
