### PR TITLE
Anchor right when overlapping the hovered element

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1,4 +1,4 @@
-var statusBar;
+var statusBar, el;
 
 if (window.top === window) {
   if (document.readyState === 'complete')
@@ -16,7 +16,7 @@ if (window.top === window) {
   function ready() { document.body.addEventListener('mouseover', hover); }
 
   function hover(e) {
-    var el = e.target;
+    el = e.target;
     while (el && el.nodeName !== 'A')
       el = el.parentNode;
 
@@ -32,6 +32,16 @@ if (window.top === window) {
       hideStatus();
   }
 
+  function elementsIntersect(a, b) {
+    a = a.getBoundingClientRect();
+    b = b.getBoundingClientRect();
+    var xIntersect = (a.left <= b.left && b.left <= a.right) ||
+      (b.left <= a.left && a.left <= b.right);
+    var yIntersect = (a.top <= b.top && b.top <= a.bottom) ||
+      (b.top <= a.top && a.top <= b.bottom);
+    return xIntersect && yIntersect;
+  }
+
   function displayStatus(text) {
     if (!statusBar) {
       statusBar = document.createElement('div');
@@ -40,11 +50,21 @@ if (window.top === window) {
     }
 
     statusBar.innerText = text;
-    setTimeout(function() { statusBar.className = 'active'; }, 1);
+    setTimeout(function() { statusBar.classList.add('active'); }, 1);
+
+    // If the statusbar overlaps the hovered element, try moving it to the
+    // right side of the viewport. If it still overlaps, give up and put it
+    // back.
+    statusBar.classList.remove('right-side');
+    if (elementsIntersect(statusBar, el)) {
+      statusBar.classList.add('right-side');
+      if (elementsIntersect(statusBar, el))
+        statusBar.classList.remove('right-side');
+    }
   }
 
   function hideStatus() {
     if (statusBar)
-      statusBar.className = '';
+      statusBar.classList.remove('active');
   }
 }

--- a/style.css
+++ b/style.css
@@ -11,11 +11,12 @@ div#com-fortnight-status-bar {
   padding: 0.125em 8px 0.25em !important;
   font: 8pt Lucida Grande !important;
   border: solid 1px #707070 !important;
-  border-left: none !important;
+  border-left-width: 0 !important;
   border-top-right-radius: 3px !important;
   text-rendering: optimizeLegibility;
   overflow: hidden;
   white-space: nowrap;
+  pointer-events: none;
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
 }
@@ -36,7 +37,9 @@ div#com-fortnight-status-bar.active {
   -webkit-transition: opacity 100ms ease-in;
 }
 
-div#com-fortnight-status-bar:hover {
-  margin-bottom: 1.5em;
-  border-bottom-right-radius: 3px;
+div#com-fortnight-status-bar.right-side {
+  left: auto;
+  right: 0;
+  border-radius: 3px 0 0 0 !important;
+  border-width: 1px 0 1px 1px !important;
 }

--- a/test.coffee
+++ b/test.coffee
@@ -4,6 +4,17 @@ http = require 'http'
 http.createServer (req, res) ->
   res.writeHead 200, 'Content-Type': 'text/html'
   res.end '''
+    <style>
+      .bottom a {
+        position: absolute;
+        bottom: 10px;
+        width: 100px;
+        outline: 1px dashed;
+      }
+      [href=left] { left: 10px; }
+      [href=center] { left: 50%; text-align: center; margin-left: -50px; }
+      [href=right] { right: 10px; text-align: right; }
+    </style>
     <ul>
       <li><a href="/relative">a relative link</a></li>
       <li><a href="http://google.com">google.com</a></li>
@@ -20,6 +31,12 @@ http.createServer (req, res) ->
       <li><a href="/relative">hold down alt</a></li>
       <li><a href="/relative">hold down control</a></li>
     </ul>
+
+    <p class="bottom">
+      <a href="left">bottom left</a>
+      <a href="center">bottom center</a>
+      <a href="right">bottom right</a>
+    </p>
   '''
 .listen 8001, '127.0.0.1'
 spawn 'open', ['http://127.0.0.1:8001']


### PR DESCRIPTION
The :hover styling wasn't working for me in practice, so I opted to give
this route a try. Probably bears playing with for a while. I'm also
ignoring pointer events on the statusbar, so if all else fails and we
end up with the bar over the hovered element, it's still possible to
click the element through the bar.

(I don't remove the right-side class in hideStatus(), since then it could
jump around during the fade-out transition.)
