### PR TITLE
Force letter-spacing to be normal

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ div#com-fortnight-status-bar {
   border: solid 1px hsl(0, 0%, 52%) !important;
   border-left-width: 0 !important;
   border-top-right-radius: 3px !important;
+  letter-spacing: normal !important;
   text-rendering: optimizeLegibility;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
I've seen a few sites that globally set a wider or narrower `letter-spacing`, so this forces it to `normal`.