### PR TITLE
Always show absolute urls

### DIFF
--- a/Settings.plist
+++ b/Settings.plist
@@ -8,9 +8,19 @@
 		<key>Key</key>
 		<string>longURL</string>
 		<key>Title</key>
-    <string>Expand shortened URLs (disabled in Private Browsing Mode)</string>
+    	<string>Expand shortened URLs (disabled in Private Browsing Mode)</string>
 		<key>Type</key>
 		<string>CheckBox</string>
 	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<false/>
+		<key>Key</key>
+		<string>absoluteURL</string>
+		<key>Title</key>
+		<string>Explicitly format URLs as absolute</string>
+		<key>Type</key>
+		<string>CheckBox</string>
+    	</dict>
 </array>
 </plist>

--- a/global.html
+++ b/global.html
@@ -16,6 +16,11 @@
                 if (url) e.target.page.dispatchMessage('displayStatus', s + ' (' +  url + ')');
               });
             }
+            break;
+          case 'getSettings':
+            e.target.page.dispatchMessage("setSettings", {
+              absoluteURL: safari.extension.settings.getItem("absoluteURL")
+            });
         }
       }, false);
 

--- a/inject.js
+++ b/inject.js
@@ -1,4 +1,4 @@
-var statusBar, el, isMetaKeyDown, isCtrlKeyDown, isAltKeyDown;
+var statusBar, el, isMetaKeyDown, isCtrlKeyDown, isAltKeyDown, absoluteURL;
 
 if (window.top === window) {
   if (document.readyState === 'complete')
@@ -10,10 +10,16 @@ if (window.top === window) {
     switch (e.name) {
       case 'displayStatus':
         displayStatus(e.message);
+        break;
+      case 'setSettings':
+        absoluteURL = e.message.absoluteURL;
     }
   }, false);
 
-  function ready() { document.body.addEventListener('mouseover', hover); }
+  function ready() {
+    document.body.addEventListener('mouseover', hover);
+    safari.self.tab.dispatchMessage('getSettings');
+  }
 
   function hover(e) {
     el = e.target;
@@ -58,6 +64,10 @@ if (window.top === window) {
   }
 
   function formatUrl(url) {
+    if (!absoluteURL) {
+      return url;
+    }
+
     var a = document.createElement('a');
     a.href = url;
     return a && a.href || url;

--- a/inject.js
+++ b/inject.js
@@ -49,12 +49,18 @@ if (window.top === window) {
 
   function dispatch() {
     safari.self.tab.dispatchMessage('hover', {
-      href: el.attributes.href.value,
+      href: formatUrl(el.attributes.href.value),
       target: el.target,
       metaKey: isMetaKeyDown,
       ctrlKey: isCtrlKeyDown,
       altKey: isAltKeyDown
     });
+  }
+
+  function formatUrl(url) {
+    var a = document.createElement('a');
+    a.href = url;
+    return a && a.href || url;
   }
 
   function elementsIntersect(a, b) {


### PR DESCRIPTION
Sometimes we see relative url:
![2015-02-26 9 14 35](https://cloud.githubusercontent.com/assets/1238365/6386243/06d3fb02-bd98-11e4-8be2-eff03d00b950.png)
and sometimes - absolute:
![2015-02-26 9 14 50](https://cloud.githubusercontent.com/assets/1238365/6386247/141c1d8a-bd98-11e4-8c49-16cf7353ee72.png)
all on the same page. 
It can be confusing plus as far as i know status bars in other browsers are always shows absolute urls.
This pull request normalizes urls to always show the absolute one.