### PR TITLE
Protect status bar appearance

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ div#com-fortnight-status-bar {
   font: 8pt Helvetica Neue !important;
   border: solid 1px hsl(0, 0%, 52%) !important;
   border-left-width: 0 !important;
-  border-top-right-radius: 3px !important;
+  border-radius: 0 3px 0 0 !important;
   letter-spacing: 0.36px !important;
   text-rendering: optimizeLegibility;
   overflow: hidden;


### PR DESCRIPTION
Setting an explicit border radius for all corners makes it less likely site stylesheets will override it.

For example, the site http://www.example.com has `div { border-radius: 1em }` in their stylesheet, which affects Minimal Status Bar because it is only explicit about the border radius for one corner.

![example](https://cloud.githubusercontent.com/assets/38445/6543702/94d5332c-c4f4-11e4-88b5-ca81bae36dbb.png)