### PR TITLE
Add localisation for Finnish

### DIFF
--- a/fi.json
+++ b/fi.json
@@ -1,0 +1,12 @@
+{
+  "email": {
+    "to": "Lähetä sähköpostia osoitteeseen {to}",
+    "subject": "Lähetä sähköpostia henkilölle {to} aiheella ”{subject}”"
+  },
+  "newWindowBehind": "Avaa ”{href}” uudessa ikkunassa nykyisen takana",
+  "newTabBehind": "Avaa ”{href}” uudella välilehdellä nykyisen takana",
+  "download": "Lataa ”{href}”",
+  "menu": "Näytä valikko kohteelle ”{href}”",
+  "newTab": "Avaa ”{href}” uudella välilehdellä",
+  "go": "Siirry kohteeseen ”{href}”"
+}


### PR DESCRIPTION
Add localisation for Finnish. This localisation matches Safari as well as the stylistic use of quotes in this extension.