### PR TITLE
Do not display a URL twice when expanding failed.

### DIFF
--- a/global.html
+++ b/global.html
@@ -19,7 +19,7 @@
               // TODO debounce?
               lengthenURL(e.message.href, function(result) {
                 var url = result['long-url'];
-                if (url) e.target.page.dispatchMessage('displayStatus', s + ' (' +  url + ')');
+                if (url && url !== e.message.href) e.target.page.dispatchMessage('displayStatus', s + ' (' +  url + ')');
               });
             }
             break;


### PR DESCRIPTION
Noticed this on ow.ly URLs, they do not change on expand:

> http://api.longurl.org/v2/expand?format=json&url=http://ow.ly/i/a0ceC
> ``` json
{"long-url":"http:\/\/ow.ly\/i\/a0ceC"}
```

This patch makes sure the status bar doesn’t show the same information twice by omitting the long url when it matches the short url.