### PR TITLE
Reset CSS for all classes.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,7 @@
-div#com-fortnight-status-bar {
+div#com-fortnight-status-bar,
+div#com-fortnight-status-bar.active,
+div#com-fortnight-status-bar.blur,
+div#com-fortnight-status-bar.right-side {
   background: linear-gradient(180deg, hsl(0, 0%, 92%) 0, hsl(0, 0%, 86%) 1px, hsl(0, 0%, 85%)) !important;
   border: solid 1px hsl(0, 0%, 52%) !important;
   border-left-width: 0 !important;


### PR DESCRIPTION
Possible fix for #74. This does the massive CSS-resetting for every class, not only for the base ID.

I am not sure if this is necessary, neither can I test it because I no longer have access to a certificate (I am not a paying member of the Apple Developer Program), but this might be an idea?
